### PR TITLE
Bytespace tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+db
+node_modules
+other.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"

--- a/modella-level.js
+++ b/modella-level.js
@@ -13,20 +13,17 @@ var level = module.exports = function(db) {
     Model.once('initialize', function() {
       for (var attr in Model.attrs) {
         if (Model.attrs[attr].index) {
-          indexedAttrs.push(attr)
+          Model.store[('by' + attr).toLowerCase()] = Secondary(Model.store, attr)
         }
       }
-
-      indexedAttrs.forEach(function(i) {
-        Model.store[('by' + i).toLowerCase()] = Secondary(Model.store, i)
-      })
     })
 
     Model.save = level.save
     Model.update = level.update
     Model.remove = level.remove
-    Model.getBy = level.getBy
     Model.find = Model.get = level.find
+    Model.findBy = Model.getBy = level.findBy
+    Model.removeBy = Model.delBy = level.removeBy
 
     return Model
   }
@@ -68,7 +65,7 @@ level.find = function(id, fn) {
   })
 }
 
-level.getBy = function(field, value, fn) {
+level.findBy = function(field, value, fn) {
   var self = this
 
   var getBy = ('by' + field).toLowerCase()
@@ -83,5 +80,23 @@ level.getBy = function(field, value, fn) {
     }
 
     fn(err, new self(value2))
+  })
+}
+
+level.removeBy = function(field, value, fn) {
+  var self = this
+
+  var getBy = ('by' + field).toLowerCase()
+
+  if (typeof this.store[getBy] == 'undefined') {
+    return fn(new Error('field does not exist'))
+  }
+  
+  this.store[getBy].del(value, function(err, value2) {
+    if (err) {
+      return fn(err)
+    }
+
+    fn(err, null)
   })
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "level-secondary": "^1.1.1"
   },
   "devDependencies": {
+    "bytespace": "^0.3.0",
+    "faucet": "0.0.1",
     "level": "^0.19.1",
     "level-sublevel": "^6.4.6",
     "memdb": "^1.0.0",
@@ -16,6 +18,6 @@
     "tape": "^4.0.0"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "tape test/*.js | faucet"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "description": "Simple middlware for Modella and LevelDB",
   "main": "modella-level.js",
   "author": "Erik Kristensen <erik@erikkristensen.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "level-secondary": "^1.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,16 @@
   "author": "Erik Kristensen <erik@erikkristensen.com>",
   "license": "MIT",
   "dependencies": {
-    "level-secondary": "^1.1.0"
+    "level-secondary": "^1.1.1"
+  },
+  "devDependencies": {
+    "level": "^0.19.1",
+    "level-sublevel": "^6.4.6",
+    "memdb": "^1.0.0",
+    "modella": "^0.2.14",
+    "tape": "^4.0.0"
+  },
+  "scripts": {
+    "test": "node test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -69,3 +69,26 @@ test('find by index', function(t) {
   })
 })
 
+
+test('del by index', function(t) {
+  t.plan(2)
+
+  var db = sublevel(level({ valueEncoding: 'json' }));
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email', { index: true })
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.delBy('email', userObj.email, function(err) {
+      t.ifError(err)
+    })
+  })
+})
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,71 @@
+var test = require('tape')
+var model = require('modella')
+var level = require('memdb')
+var sublevel = require('level-sublevel')
+var modeldb = require('./modella-level')
+
+test('save', function(t) {
+  t.plan(1)
+
+  var db = sublevel(level({ valueEncoding: 'json' }));
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email')
+
+  var u = new User({id: 1, email: 'one@one.com'})
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+  })
+
+})
+
+
+test('find by id', function(t) {
+  t.plan(3)
+
+  var db = sublevel(level({ valueEncoding: 'json' }));
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email')
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.find(1, function(err, user) {
+      t.ok(!err)
+      t.equal(JSON.stringify(user.toJSON()), JSON.stringify(userObj))
+    })
+  })
+})
+
+
+test('find by index', function(t) {
+  t.plan(3)
+
+  var db = sublevel(level({ valueEncoding: 'json' }));
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email', { index: true })
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.getBy('email', userObj.email, function(err, user) {
+      t.ifError(err)
+      t.equal(JSON.stringify(user.toJSON()), JSON.stringify(userObj))
+    })
+  })
+})
+

--- a/test/bytespace.js
+++ b/test/bytespace.js
@@ -1,0 +1,94 @@
+var test = require('tape')
+var model = require('modella')
+var level = require('memdb')
+var subspace = require('bytespace')
+var modeldb = require('../modella-level')
+
+test('save', function(t) {
+  t.plan(1)
+
+  var db = subspace(level(), '', { valueEncoding: 'json' });
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email')
+
+  var u = new User({id: 1, email: 'one@one.com'})
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+  })
+
+})
+
+
+test('find by id', function(t) {
+  t.plan(3)
+
+  var db = subspace(level(), '', { valueEncoding: 'json' });
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email')
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.find(1, function(err, user) {
+      t.ok(!err)
+      t.equal(JSON.stringify(user.toJSON()), JSON.stringify(userObj))
+    })
+  })
+})
+
+
+test('find by index', function(t) {
+  t.plan(3)
+
+  var db = subspace(level(), '', { valueEncoding: 'json' });
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email', { index: true })
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.getBy('email', userObj.email, function(err, user) {
+      t.ifError(err)
+      t.equal(JSON.stringify(user.toJSON()), JSON.stringify(userObj))
+    })
+  })
+})
+
+
+test('del by index', function(t) {
+  t.plan(2)
+
+  var db = subspace(level(), '', { valueEncoding: 'json' });
+  
+  var User = model('user')
+    .use(modeldb(db))
+    .attr('id')
+    .attr('email', { index: true })
+
+  var userObj = {id: 1, email: "test@test.com"}
+
+  var u = new User(userObj)
+  u.save(function(err, user_data) {
+    t.ok(!err)    
+    
+    User.delBy('email', userObj.email, function(err) {
+      t.ifError(err)
+    })
+  })
+})
+

--- a/test/sublevel.js
+++ b/test/sublevel.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var model = require('modella')
 var level = require('memdb')
 var sublevel = require('level-sublevel')
-var modeldb = require('./modella-level')
+var modeldb = require('../modella-level')
 
 test('save', function(t) {
   t.plan(1)


### PR DESCRIPTION
This adds some tests to show the secondary indexing working with [bytespace](https://github.com/deanlandolt/bytespace). Still not a perfect drop-in for sublevel -- due to an annoying `updown` bug the root db can't be `valueEncoding: json`.

This isn't _such_ a problem, but still kind of stupid. Sunk hours into trying to find workarounds but it's all pretty kludgy -- ends up duplicating a lot of the encoding nonsense `sublevel` has to do that we're _supposed_ to be able to completely avoid in the first place by using `updown`.

_EDIT_: I just realized I sent this PR against master -- let me know if you want me to kill it and send one against the `indexes` branch.
